### PR TITLE
Improve search query handling with length limits and better encoding

### DIFF
--- a/indexer/src/scrapers/wawacity.ts
+++ b/indexer/src/scrapers/wawacity.ts
@@ -82,6 +82,13 @@ export class WawacityScraper implements BaseScraper {
           searchTerm += ` Saison ${params.season}`;
         }
 
+        // WawaCity limite: max 32 caractères (espaces inclus)
+        // Si la limite est dépassée, la liste complète des films est renvoyée au lieu des résultats de recherche
+        if (searchTerm.length > 32) {
+          searchTerm = searchTerm.substring(0, 32).trim();
+          console.log(`[WawaCity] Truncated search term to 32 chars: "${searchTerm}"`);
+        }
+
         const baseSearchUrl = `${this.baseUrl}/?p=${wawaType}&linkType=hasDownloadLink&search=${encodeSearchQuery(searchTerm)}`;
         console.log(`[WawaCity] Searching ${contentType} with variant "${variant}": ${baseSearchUrl}`);
 

--- a/indexer/src/scrapers/zonetelecharger.ts
+++ b/indexer/src/scrapers/zonetelecharger.ts
@@ -76,6 +76,13 @@ export class ZoneTelechargerScraper implements BaseScraper {
           searchTerm += ` Saison ${params.season}`;
         }
 
+        // Zone-Téléchargement limit: max 36 caractères (espaces inclus)
+        // Si la limite est dépassée, la liste complète des films est renvoyée au lieu des résultats de recherche
+        if (searchTerm.length > 36) {
+          searchTerm = searchTerm.substring(0, 36).trim();
+          console.log(`[ZoneTelecharger] Truncated search term to 36 chars: "${searchTerm}"`);
+        }
+
         const baseSearchUrl = `${this.baseUrl}/?search=${encodeSearchQuery(searchTerm)}&p=${ztType}`;
         console.log(`[ZoneTelecharger] Searching ${contentType} with variant "${variant}": ${baseSearchUrl}`);
 

--- a/indexer/src/utils/http.ts
+++ b/indexer/src/utils/http.ts
@@ -90,5 +90,7 @@ export async function fetchJson<T>(url: string, configOpts?: AxiosRequestConfig)
 }
 
 export function encodeSearchQuery(query: string): string {
-  return encodeURIComponent(query.trim().toLowerCase());
+  // Préserver la casse et utiliser un encodage simple des espaces en signes plus.
+  // La plupart des sites DDL fonctionnent mieux avec un encodage simple.
+  return query.trim().replace(/\s+/g, '+');
 }

--- a/indexer/src/utils/text.ts
+++ b/indexer/src/utils/text.ts
@@ -23,6 +23,15 @@ export function generateAccentVariants(query: string, maxVariants: number = 5): 
   const variants = new Set<string>();
   variants.add(query); // Toujours inclure l'original
 
+  // Si le texte original contient déjà des accents, c'est probablement un titre français
+  // Sinon (titre anglais), on limite la génération de variantes accentuées
+  const hasAccents = /[àâäæçéèêëïîôùûüÿœ]/i.test(query);
+
+  // Pour les titres anglais, on retourne juste l'original sans générer de variantes accentuées
+  if (!hasAccents) {
+    return [query];
+  }
+
   const lowerQuery = query.toLowerCase();
   const words = lowerQuery.split(/\s+/);
 


### PR DESCRIPTION
Improve search query handling with length limits and better encoding
- Add search term length limits for WawaCity (32 chars) and Zone-Téléchargement (36 chars)
- Change query encoding to use simple '+' replacement instead of full URI encoding
- Skip accent variant generation for English titles without accents
- Preserve case in search queries for better site compatibility