### PR TITLE
Improve search query handling with length limits

### DIFF
--- a/indexer/src/scrapers/wawacity.ts
+++ b/indexer/src/scrapers/wawacity.ts
@@ -82,6 +82,13 @@ export class WawacityScraper implements BaseScraper {
           searchTerm += ` Saison ${params.season}`;
         }
 
+        // WawaCity limite: max 32 caractères (espaces inclus)
+        // Si la limite est dépassée, la liste complète des films est renvoyée au lieu des résultats de recherche
+        if (searchTerm.length > 32) {
+          searchTerm = searchTerm.substring(0, 32).trim();
+          console.log(`[WawaCity] Truncated search term to 32 chars: "${searchTerm}"`);
+        }
+
         const baseSearchUrl = `${this.baseUrl}/?p=${wawaType}&linkType=hasDownloadLink&search=${encodeSearchQuery(searchTerm)}`;
         console.log(`[WawaCity] Searching ${contentType} with variant "${variant}": ${baseSearchUrl}`);
 

--- a/indexer/src/scrapers/zonetelecharger.ts
+++ b/indexer/src/scrapers/zonetelecharger.ts
@@ -76,6 +76,13 @@ export class ZoneTelechargerScraper implements BaseScraper {
           searchTerm += ` Saison ${params.season}`;
         }
 
+        // Zone-Téléchargement limit: max 36 caractères (espaces inclus)
+        // Si la limite est dépassée, la liste complète des films est renvoyée au lieu des résultats de recherche
+        if (searchTerm.length > 36) {
+          searchTerm = searchTerm.substring(0, 36).trim();
+          console.log(`[ZoneTelecharger] Truncated search term to 36 chars: "${searchTerm}"`);
+        }
+
         const baseSearchUrl = `${this.baseUrl}/?search=${encodeSearchQuery(searchTerm)}&p=${ztType}`;
         console.log(`[ZoneTelecharger] Searching ${contentType} with variant "${variant}": ${baseSearchUrl}`);
 

--- a/indexer/src/utils/http.ts
+++ b/indexer/src/utils/http.ts
@@ -90,5 +90,6 @@ export async function fetchJson<T>(url: string, configOpts?: AxiosRequestConfig)
 }
 
 export function encodeSearchQuery(query: string): string {
-  return encodeURIComponent(query.trim().toLowerCase());
+  return encodeURIComponent(query.trim().toLowerCase())
+    .replace(/%20/g, '+');
 }


### PR DESCRIPTION
Improve search query handling with length limits and better encoding
- Add search term length limits for WawaCity (32 chars) and Zone-Téléchargement (36 chars)
- Change query encoding to use simple '+' replacement