### PR TITLE
feat(prowlarr): add Cardigann custom indexer definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,11 @@ docker compose --profile blackhole up -d
 
 > Remplacer `<IP>` par l'adresse du serveur (ex: `192.168.1.100`, `localhost`, ou votre domaine)
 
+### Intégration Prowlarr
+
+Pour une intégration simplifiée avec Prowlarr, une définition Cardigann custom est disponible.
+Voir [prowlarr/README.md](prowlarr/README.md) pour les instructions d'installation.
+
 ### Filtrage par hébergeur
 
 Vous pouvez filtrer les résultats pour n'afficher que les liens d'un ou plusieurs hébergeurs spécifiques. Cela permet de ne garder que les hébergeurs supportés par votre service debrid.

--- a/prowlarr/README.md
+++ b/prowlarr/README.md
@@ -1,0 +1,74 @@
+# DDL Torznab - Prowlarr Custom Indexer
+
+Cette définition Cardigann permet d'ajouter DDL Torznab comme indexeur natif dans Prowlarr.
+
+> **Note** : Cette définition n'a pas été testée. Si vous rencontrez des problèmes, utilisez l'Option 2 (Generic Torznab) qui fonctionne de manière fiable.
+
+## Installation
+
+### Option 1 : Définition Custom (recommandé)
+
+1. Copier le fichier `ddl-torznab.yml` dans le dossier des définitions custom de Prowlarr :
+   - **Linux** : `~/.config/Prowlarr/Definitions/Custom/`
+   - **Docker** : `/config/Definitions/Custom/`
+   - **Windows** : `%AppData%\Prowlarr\Definitions\Custom\`
+
+2. Redémarrer Prowlarr
+
+3. Ajouter l'indexeur :
+   - Aller dans **Settings > Indexers > Add Indexer**
+   - Chercher "DDL Torznab"
+   - Configurer l'URL (par défaut : `http://ddl-torznab:3000`)
+   - Sélectionner le site source (Darkiworld, ZoneTelecharger, WawaCity)
+
+### Option 2 : Generic Torznab
+
+Si la définition custom ne fonctionne pas, utiliser l'indexeur Torznab générique :
+
+1. Dans Prowlarr : **Settings > Indexers > Add Indexer**
+2. Sélectionner **Generic Torznab**
+3. Configurer :
+   - **Name** : DDL Torznab - Darkiworld (ou autre site)
+   - **URL** : `http://ddl-torznab:3000/api/darkiworld`
+   - **API Key** : laisser vide
+   - **Categories** : Movies, TV
+
+## Configuration
+
+| Paramètre | Description | Exemple |
+|-----------|-------------|---------|
+| DDL Torznab URL | URL du service DDL Torznab | `http://ddl-torznab:3000` |
+| Source Site | Site DDL à utiliser | `darkiworld` |
+
+## Sites disponibles
+
+- **Darkiworld** : Films et séries FR
+- **ZoneTelecharger** : Films et séries FR
+- **WawaCity** : Films, séries et ebooks FR
+
+## Filtrer par hébergeur
+
+Pour filtrer par hébergeur spécifique, utiliser l'URL avec le chemin :
+```
+http://ddl-torznab:3000/api/darkiworld/1fichier
+http://ddl-torznab:3000/api/darkiworld/uptobox,1fichier
+```
+
+## Docker Compose
+
+Si vous utilisez Docker Compose avec Prowlarr :
+
+```yaml
+services:
+  prowlarr:
+    image: linuxserver/prowlarr
+    volumes:
+      - ./prowlarr:/config
+      - ./prowlarr/ddl-torznab.yml:/config/Definitions/Custom/ddl-torznab.yml:ro
+```
+
+## Dépannage
+
+- **Indexeur non visible** : Redémarrer Prowlarr après avoir copié le fichier
+- **Erreur de connexion** : Vérifier que DDL Torznab est accessible depuis Prowlarr (même réseau Docker)
+- **Pas de résultats** : Tester avec l'interface web de DDL Torznab directement

--- a/prowlarr/ddl-torznab.yml
+++ b/prowlarr/ddl-torznab.yml
@@ -1,0 +1,92 @@
+---
+id: ddl-torznab
+name: DDL Torznab
+description: "French Direct Download Links indexer - Converts DDL sites to Torznab API"
+language: fr-FR
+type: public
+encoding: UTF-8
+
+links:
+  - http://ddl-torznab:3000
+
+settings:
+  - name: baseurl
+    type: text
+    label: DDL Torznab URL
+    default: "http://ddl-torznab:3000"
+  - name: site
+    type: select
+    label: Source Site
+    default: darkiworld
+    options:
+      darkiworld: Darkiworld
+      zonetelecharger: ZoneTelechargement
+      wawacity: WawaCity
+  - name: hosters
+    type: text
+    label: Preferred Hosters (comma separated, empty for all)
+    default: ""
+
+caps:
+  categorymappings:
+    - {id: 2000, cat: Movies, desc: "Movies"}
+    - {id: 2030, cat: Movies/SD, desc: "Movies/SD"}
+    - {id: 2040, cat: Movies/HD, desc: "Movies/HD"}
+    - {id: 2045, cat: Movies/UHD, desc: "Movies/4K"}
+    - {id: 2060, cat: Movies/3D, desc: "Movies/3D"}
+    - {id: 5000, cat: TV, desc: "TV"}
+    - {id: 5030, cat: TV/SD, desc: "TV/SD"}
+    - {id: 5040, cat: TV/HD, desc: "TV/HD"}
+    - {id: 5045, cat: TV/UHD, desc: "TV/4K"}
+    - {id: 5070, cat: TV/Anime, desc: "Anime"}
+    - {id: 7000, cat: Books, desc: "Books"}
+    - {id: 7010, cat: Books/Mags, desc: "Books/Magazines"}
+    - {id: 7020, cat: Books/EBook, desc: "Books/eBooks"}
+    - {id: 7030, cat: Books/Comics, desc: "Books/Comics"}
+
+  modes:
+    search: [q]
+    tv-search: [q, season, ep, imdbid, tvdbid]
+    movie-search: [q, imdbid, tmdbid]
+    book-search: [q]
+
+search:
+  paths:
+    - path: "{{ .Config.baseurl }}/api/{{ .Config.site }}{{ if .Config.hosters }}/{{ .Config.hosters }}{{ end }}"
+      response:
+        type: xml
+
+  inputs:
+    t: "{{ if .Query.IMDBID }}movie{{ else if .Query.TVDBID }}tvsearch{{ else }}search{{ end }}"
+    q: "{{ .Keywords }}"
+    imdbid: "{{ .Query.IMDBIDShort }}"
+    tmdbid: "{{ .Query.TMDBID }}"
+    tvdbid: "{{ .Query.TVDBID }}"
+    season: "{{ .Query.Season }}"
+    ep: "{{ .Query.Ep }}"
+    limit: 100
+
+  rows:
+    selector: rss > channel > item
+
+  fields:
+    category:
+      selector: category
+    title:
+      selector: title
+    details:
+      selector: comments
+    download:
+      selector: link
+    size:
+      selector: size
+    date:
+      selector: pubDate
+    seeders:
+      text: 100
+    leechers:
+      text: 0
+    downloadvolumefactor:
+      text: 0
+    uploadvolumefactor:
+      text: 1


### PR DESCRIPTION
Add Prowlarr custom indexer definition for simplified integration:
- ddl-torznab.yml: Cardigann v11 definition with site selector and hosters filter
- README with installation instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)