### PR TITLE
fix(ui): prevent loading state from blocking polling updates

### DIFF
--- a/qbittorrent/ui/src/App.vue
+++ b/qbittorrent/ui/src/App.vue
@@ -23,7 +23,7 @@ onUnmounted(() => {
 
 function startPolling() {
   pollInterval = window.setInterval(() => {
-    store.fetchTorrents()
+    store.fetchTorrents(false)  // Don't show loading state during polling
   }, 2000)
 }
 

--- a/qbittorrent/ui/src/stores/torrents.ts
+++ b/qbittorrent/ui/src/stores/torrents.ts
@@ -49,9 +49,11 @@ export const useTorrentsStore = defineStore('torrents', () => {
     torrents.value = []
   }
 
-  async function fetchTorrents(): Promise<void> {
+  async function fetchTorrents(showLoading = true): Promise<void> {
     try {
-      isLoading.value = true
+      if (showLoading) {
+        isLoading.value = true
+      }
       error.value = null
       torrents.value = await apiClient.getTorrents()
     } catch (e: any) {
@@ -60,7 +62,9 @@ export const useTorrentsStore = defineStore('torrents', () => {
       }
       error.value = e.message
     } finally {
-      isLoading.value = false
+      if (showLoading) {
+        isLoading.value = false
+      }
     }
   }
 


### PR DESCRIPTION
The isLoading state was being set during background polling, which could interfere with UI updates. Now polling uses showLoading=false to keep the UI responsive while data refreshes in the background.