### PR TITLE
fix(indexer): default to SD category when quality is unknown

### DIFF
--- a/indexer/src/scrapers/base.ts
+++ b/indexer/src/scrapers/base.ts
@@ -119,16 +119,14 @@ export function contentTypeToCategory(contentType: ContentType, quality?: string
   if (contentType === 'movie') {
     if (isUHD) return 2045;
     if (isHD) return 2040;
-    if (isSD) return 2030;
-    return 2000; // Unknown quality → generic category
+    return 2030; // SD or unknown quality
   }
 
   if (contentType === 'series') {
     if (isUHD) return 5045;
     if (isHD) return 5040;
-    if (isSD) return 5030;
-    return 5000; // Unknown quality → generic category
+    return 5030; // SD or unknown quality
   }
 
-  return 2000;
+  return 2030;
 }


### PR DESCRIPTION
When no quality indicator (1080p, 720p, etc.) is found in the title, default to MoviesSD/TVSD instead of the generic parent category. Content without explicit HD/UHD tags is more likely SD, and this helps Radarr/Sonarr categorize results more accurately.