### PR TITLE
feat(qbittorrent): add magnet URI support via debrid services

### DIFF
--- a/qbittorrent/src/debrid/alldebrid.ts
+++ b/qbittorrent/src/debrid/alldebrid.ts
@@ -204,6 +204,42 @@ export class AllDebridClient implements DebridService {
     throw new Error('Failed to upload torrent');
   }
 
+  async uploadMagnet(magnetUri: string): Promise<string> {
+    const config = getConfig().debrid.alldebrid;
+
+    if (!config.apiKey) {
+      throw new Error('AllDebrid not configured');
+    }
+
+    console.log(`[AllDebrid] Uploading magnet URI`);
+
+    const formData = new FormData();
+    formData.append('magnets[]', magnetUri);
+
+    const response = await axios.post<AllDebridResponse<MagnetUploadResponse>>(
+      `${ALLDEBRID_API_BASE}/magnet/upload`,
+      formData,
+      {
+        headers: {
+          'Authorization': `Bearer ${config.apiKey}`,
+        },
+        timeout: 60000,
+      }
+    );
+
+    if (response.data.status === 'success' && response.data.data?.magnets?.[0]) {
+      const magnet = response.data.data.magnets[0];
+      console.log(`[AllDebrid] Magnet uploaded, id: ${magnet.id}, name: ${magnet.name}, ready: ${magnet.ready}`);
+      return String(magnet.id);
+    }
+
+    if (response.data.error) {
+      throw new Error(`${response.data.error.message} (${response.data.error.code})`);
+    }
+
+    throw new Error('Failed to upload magnet');
+  }
+
   async getTorrentStatus(torrentId: string): Promise<DebridTorrentStatus> {
     const config = getConfig().debrid.alldebrid;
 

--- a/qbittorrent/src/debrid/base.ts
+++ b/qbittorrent/src/debrid/base.ts
@@ -60,6 +60,12 @@ export interface DebridService {
   uploadTorrent(torrentBuffer: Buffer, filename?: string): Promise<string>;
 
   /**
+   * Upload a magnet URI to the debrid service
+   * Returns the torrent ID for status tracking
+   */
+  uploadMagnet(magnetUri: string): Promise<string>;
+
+  /**
    * Get the status of an uploaded torrent
    */
   getTorrentStatus(torrentId: string): Promise<DebridTorrentStatus>;

--- a/qbittorrent/src/debrid/index.ts
+++ b/qbittorrent/src/debrid/index.ts
@@ -170,3 +170,74 @@ export async function debridTorrent(
 
   throw lastError || new Error('All debrid services failed to process torrent');
 }
+
+/**
+ * Upload a magnet URI to a debrid service and wait for it to be ready
+ * Polls the service until the torrent is ready or an error occurs
+ */
+export async function debridMagnet(
+  magnetUri: string,
+  onStatusUpdate?: (status: DebridTorrentStatus, serviceName: string) => void,
+  timeoutMs: number = 24 * 60 * 60 * 1000, // 24 hours default
+  pollIntervalMs: number = 5000
+): Promise<DebridTorrentResult> {
+  const enabledServices = getTorrentEnabledServices();
+
+  if (enabledServices.length === 0) {
+    throw new Error('No debrid service with torrent support is enabled');
+  }
+
+  let lastError: Error | null = null;
+
+  for (const service of enabledServices) {
+    try {
+      console.log(`[Debrid] Trying ${service.name} for magnet upload...`);
+
+      // Upload magnet
+      const torrentId = await service.uploadMagnet(magnetUri);
+      console.log(`[Debrid] ${service.name}: Magnet uploaded with id ${torrentId}`);
+
+      // Poll for completion
+      const startTime = Date.now();
+
+      while (Date.now() - startTime < timeoutMs) {
+        const status = await service.getTorrentStatus(torrentId);
+
+        if (onStatusUpdate) {
+          onStatusUpdate(status, service.name);
+        }
+
+        // Check if ready - prefer files array over downloadLinks
+        const hasFiles = status.files && status.files.length > 0;
+        const hasLinks = status.downloadLinks && status.downloadLinks.length > 0;
+
+        if (status.status === 'ready' && (hasFiles || hasLinks)) {
+          const fileCount = hasFiles ? status.files!.length : status.downloadLinks!.length;
+          console.log(`[Debrid] ${service.name}: Magnet ready with ${fileCount} file(s), size: ${status.totalSize}`);
+          return {
+            service: service.name,
+            torrentId,
+            downloadLinks: status.downloadLinks || status.files!.map(f => f.link),
+            files: status.files,
+            totalSize: status.totalSize,
+          };
+        }
+
+        if (status.status === 'error') {
+          throw new Error(status.errorMessage || 'Magnet processing failed');
+        }
+
+        // Wait before next poll
+        await new Promise(resolve => setTimeout(resolve, pollIntervalMs));
+      }
+
+      throw new Error(`Timeout waiting for magnet after ${Math.round(timeoutMs / 1000 / 60)} minutes`);
+    } catch (error: any) {
+      console.warn(`[Debrid] ${service.name} failed: ${error.message}`);
+      lastError = error;
+      // Continue to next service
+    }
+  }
+
+  throw lastError || new Error('All debrid services failed to process magnet');
+}

--- a/qbittorrent/src/debrid/premiumize.ts
+++ b/qbittorrent/src/debrid/premiumize.ts
@@ -172,6 +172,41 @@ export class PremiumizeClient implements DebridService {
     throw new Error('Failed to upload torrent');
   }
 
+  async uploadMagnet(magnetUri: string): Promise<string> {
+    const config = getConfig().debrid.premiumize;
+
+    if (!config.apiKey) {
+      throw new Error('Premiumize not configured');
+    }
+
+    console.log(`[Premiumize] Uploading magnet URI`);
+
+    const response = await axios.post<PremiumizeResponse<PremiumizeTransferCreate>>(
+      `${PREMIUMIZE_API_BASE}/transfer/create`,
+      `src=${encodeURIComponent(magnetUri)}`,
+      {
+        params: {
+          apikey: config.apiKey,
+        },
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        timeout: 60000,
+      }
+    );
+
+    if (response.data.status === 'success' && response.data.content?.id) {
+      console.log(`[Premiumize] Magnet uploaded, id: ${response.data.content.id}`);
+      return response.data.content.id;
+    }
+
+    if (response.data.message) {
+      throw new Error(response.data.message);
+    }
+
+    throw new Error('Failed to upload magnet');
+  }
+
   async getTorrentStatus(torrentId: string): Promise<DebridTorrentStatus> {
     const config = getConfig().debrid.premiumize;
 

--- a/qbittorrent/src/debrid/realdebrid.ts
+++ b/qbittorrent/src/debrid/realdebrid.ts
@@ -164,6 +164,39 @@ export class RealDebridClient implements DebridService {
     throw new Error('Failed to upload torrent');
   }
 
+  async uploadMagnet(magnetUri: string): Promise<string> {
+    const config = getConfig().debrid.realdebrid;
+
+    if (!config.apiKey) {
+      throw new Error('Real-Debrid not configured');
+    }
+
+    console.log(`[Real-Debrid] Uploading magnet URI`);
+
+    const response = await axios.post<{ id: string; uri: string }>(
+      `${REALDEBRID_API_BASE}/torrents/addMagnet`,
+      `magnet=${encodeURIComponent(magnetUri)}`,
+      {
+        headers: {
+          'Authorization': `Bearer ${config.apiKey}`,
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        timeout: 60000,
+      }
+    );
+
+    if (response.data.id) {
+      console.log(`[Real-Debrid] Magnet uploaded, id: ${response.data.id}`);
+
+      // Real-Debrid requires selecting files after upload
+      await this.selectAllFiles(response.data.id);
+
+      return response.data.id;
+    }
+
+    throw new Error('Failed to upload magnet');
+  }
+
   private async selectAllFiles(torrentId: string): Promise<void> {
     const config = getConfig().debrid.realdebrid;
 

--- a/qbittorrent/src/services/download-manager.ts
+++ b/qbittorrent/src/services/download-manager.ts
@@ -8,7 +8,7 @@ import {
   extractSizeFromTorrentBuffer,
 } from '../utils/torrent.js';
 import { isDlProtectLink, resolveDlProtectLink } from '../utils/dlprotect.js';
-import { debridLink, debridTorrent, isAnyDebridEnabled, getTorrentEnabledServices } from '../debrid/index.js';
+import { debridLink, debridTorrent, debridMagnet, isAnyDebridEnabled, getTorrentEnabledServices } from '../debrid/index.js';
 import { startDownload, stopDownload, pauseDownload, getDownloadProgress, isDownloadActive, isDownloadPaused, getPausedDownloadInfo } from './downloader.js';
 import * as repository from '../db/repository.js';
 import type { Download, DownloadState, DownloadType } from '../types/download.js';
@@ -319,6 +319,63 @@ class DownloadManager {
       console.log(`[DownloadManager] URL parsing failed, treating as direct link: ${error.message}`);
     }
 
+    // Detect magnet URIs
+    if (url.startsWith('magnet:')) {
+      const torrentServices = getTorrentEnabledServices();
+      if (torrentServices.length === 0) {
+        throw new Error('No debrid service with torrent support is enabled');
+      }
+
+      const hash = generateDownloadHash(url);
+      const config = getConfig();
+
+      // Extract name from magnet dn= parameter
+      let name = options.name;
+      if (!name) {
+        try {
+          const magnetUrl = new URL(url);
+          const dn = magnetUrl.searchParams.get('dn');
+          name = dn ? decodeURIComponent(dn) : `magnet_${Date.now()}`;
+        } catch {
+          name = `magnet_${Date.now()}`;
+        }
+      }
+
+      let savePath = options.savePath || config.downloadPath;
+      if (options.category && !options.savePath) {
+        savePath = `${config.downloadPath}/${options.category}`;
+      }
+
+      const download: Omit<Download, 'downloadSpeed'> = {
+        hash,
+        name,
+        type: 'magnet',
+        originalLink: url,
+        debridedLink: null,
+        debridTorrentId: null,
+        savePath,
+        totalSize: 0,
+        downloadedSize: 0,
+        state: options.paused ? 'paused' : 'queued',
+        statusMessage: null,
+        errorMessage: null,
+        addedAt: Date.now(),
+        startedAt: null,
+        completedAt: null,
+        category: options.category || null,
+        priority: 0,
+      };
+
+      repository.createDownload(download);
+      console.log(`[DownloadManager] Added magnet download: ${name} (${hash})`);
+
+      if (!options.paused) {
+        this.processQueue();
+      }
+
+      return hash;
+    }
+
     const hash = generateDownloadHash(url);
     const config = getConfig();
 
@@ -578,6 +635,8 @@ class DownloadManager {
     // Route to appropriate handler based on type
     if (download.type === 'real') {
       await this.startProcessingRealTorrent(download);
+    } else if (download.type === 'magnet') {
+      await this.startProcessingMagnet(download);
     } else {
       await this.startProcessingDdl(download);
     }
@@ -793,6 +852,215 @@ class DownloadManager {
         if (dl) {
           repository.updateDownloadState(hash, 'error', error.message);
           console.error(`[DownloadManager] Real torrent error: ${name} - ${error.message}`);
+        }
+      }
+      this.processQueue();
+    } finally {
+      // Always clean up operation tracking
+      this.activeDebridOperations.delete(hash);
+    }
+  }
+
+  /**
+   * Process a magnet URI (upload to debrid, wait for completion, download files)
+   */
+  private async startProcessingMagnet(download: Download): Promise<void> {
+    const { hash, name, savePath, originalLink } = download;
+
+    // Track this debrid operation for cancellation
+    const operation = { cancelled: false };
+    this.activeDebridOperations.set(hash, operation);
+
+    try {
+      repository.updateDownloadState(hash, 'checking');
+
+      // Upload magnet to debrid service
+      repository.updateDownloadStatusMessage(hash, 'Uploading magnet to debrid...');
+      console.log(`[DownloadManager] Uploading magnet: ${name}`);
+
+      const config = getConfig();
+      const timeoutMs = config.debridTorrentTimeoutHours * 60 * 60 * 1000;
+
+      const result = await debridMagnet(
+        originalLink,
+        (status, serviceName) => {
+          // Check if cancelled during polling
+          if (operation.cancelled) {
+            throw new Error('Download cancelled');
+          }
+          // Update status message based on debrid status
+          if (status.status === 'queued') {
+            repository.updateDownloadStatusMessage(hash, `Queued on ${serviceName}...`);
+          } else if (status.status === 'downloading') {
+            repository.updateDownloadStatusMessage(hash, `Downloading on debrid: ${status.progress}%`);
+          }
+        },
+        timeoutMs
+      );
+
+      // Check if cancelled after debrid completed
+      if (operation.cancelled) {
+        console.log(`[DownloadManager] Magnet cancelled after debrid: ${name}`);
+        return;
+      }
+
+      console.log(`[DownloadManager] Magnet ready on ${result.service}, ${result.downloadLinks.length} file(s)`);
+
+      // If single file, download it directly
+      // If multiple files, download each sequentially
+      if (result.downloadLinks.length === 1) {
+        const debridedUrl = result.downloadLinks[0];
+        repository.updateDownloadLink(hash, debridedUrl);
+
+        // Get real filename
+        repository.updateDownloadStatusMessage(hash, 'Getting file info...');
+        let actualName = name;
+        try {
+          actualName = await getRealFilename(debridedUrl, name);
+          if (actualName !== name) {
+            repository.updateDownloadName(hash, actualName);
+          }
+        } catch (error: any) {
+          console.log(`[DownloadManager] Could not get real filename: ${error.message}`);
+        }
+
+        // Start download
+        repository.updateDownloadStatusMessage(hash, null);
+        repository.updateDownloadState(hash, 'downloading');
+
+        startDownload(hash, debridedUrl, actualName, {
+          onProgress: (progress) => {
+            repository.updateDownloadProgress(hash, progress.downloadedBytes, progress.totalBytes, progress.downloadSpeed);
+          },
+          onMoving: (finalPath) => {
+            const dl = repository.getDownloadByHash(hash);
+            if (dl && dl.totalSize > 0) {
+              repository.updateDownloadProgress(hash, dl.totalSize, dl.totalSize, 0);
+            }
+            repository.updateDownloadStatusMessage(hash, `Moving to ${finalPath}...`);
+          },
+          onMoveProgress: (copiedBytes, totalBytes, speed) => {
+            const percent = Math.round((copiedBytes / totalBytes) * 100);
+            repository.updateDownloadStatusMessage(hash, `Copying... ${percent}% - ${formatSpeed(speed)}`);
+          },
+          onExtracting: () => {
+            repository.updateDownloadStatusMessage(hash, 'Extracting...');
+          },
+          onComplete: () => {
+            repository.updateDownloadState(hash, 'completed');
+            console.log(`[DownloadManager] Completed: ${name}`);
+            this.processQueue();
+          },
+          onError: (error) => {
+            repository.updateDownloadState(hash, 'error', error.message);
+            console.error(`[DownloadManager] Error: ${name} - ${error.message}`);
+            this.processQueue();
+          },
+          onPaused: () => {
+            console.log(`[DownloadManager] Download paused: ${name}`);
+          },
+        }, result.totalSize, savePath);
+      } else {
+        // Multiple files - download them sequentially into a folder
+        console.log(`[DownloadManager] Multi-file magnet with ${result.downloadLinks.length} files`);
+
+        // Create folder with torrent name
+        const torrentFolder = path.join(savePath, name);
+        if (!fs.existsSync(torrentFolder)) {
+          fs.mkdirSync(torrentFolder, { recursive: true });
+          console.log(`[DownloadManager] Created folder: ${torrentFolder}`);
+        }
+
+        // Download all files sequentially
+        repository.updateDownloadStatusMessage(hash, null);
+        repository.updateDownloadState(hash, 'downloading');
+
+        const totalFiles = result.downloadLinks.length;
+        let completedFiles = 0;
+        let totalDownloaded = 0;
+
+        const downloadNextFile = async (index: number) => {
+          if (index >= totalFiles) {
+            // All files completed
+            repository.updateDownloadState(hash, 'completed');
+            console.log(`[DownloadManager] Completed all ${totalFiles} files: ${name}`);
+            this.processQueue();
+            return;
+          }
+
+          const debridedUrl = result.downloadLinks[index];
+          repository.updateDownloadStatusMessage(hash, `File ${index + 1}/${totalFiles}: Getting info...`);
+
+          // Get real filename for this file
+          let filename = `file_${index + 1}`;
+          try {
+            filename = await getRealFilename(debridedUrl, filename);
+            console.log(`[DownloadManager] File ${index + 1}/${totalFiles}: ${filename}`);
+          } catch (error: any) {
+            console.log(`[DownloadManager] Could not get filename for file ${index + 1}: ${error.message}`);
+          }
+
+          repository.updateDownloadStatusMessage(hash, `File ${index + 1}/${totalFiles}: ${filename}`);
+
+          // Use a unique hash for each file download to avoid conflicts
+          const fileHash = `${hash}_file_${index}`;
+
+          startDownload(fileHash, debridedUrl, filename, {
+            onProgress: (progress) => {
+              // Update global progress considering completed files
+              const currentFileProgress = progress.downloadedBytes;
+              const globalDownloaded = totalDownloaded + currentFileProgress;
+              repository.updateDownloadProgress(hash, globalDownloaded, result.totalSize || 0, progress.downloadSpeed);
+              repository.updateDownloadStatusMessage(hash, `File ${index + 1}/${totalFiles}: ${filename} (${progress.progress}%)`);
+            },
+            onMoving: () => {
+              repository.updateDownloadStatusMessage(hash, `File ${index + 1}/${totalFiles}: Moving ${filename}...`);
+            },
+            onMoveProgress: (copiedBytes, totalBytes, speed) => {
+              const percent = Math.round((copiedBytes / totalBytes) * 100);
+              repository.updateDownloadStatusMessage(hash, `File ${index + 1}/${totalFiles}: Copying ${filename}... ${percent}%`);
+            },
+            onExtracting: () => {
+              repository.updateDownloadStatusMessage(hash, `File ${index + 1}/${totalFiles}: Extracting ${filename}...`);
+            },
+            onComplete: (finalPath) => {
+              completedFiles++;
+              // Get file size and add to total downloaded
+              try {
+                const stats = fs.statSync(finalPath);
+                totalDownloaded += stats.size;
+              } catch {}
+              console.log(`[DownloadManager] Completed file ${completedFiles}/${totalFiles}: ${filename}`);
+              // Download next file
+              downloadNextFile(index + 1);
+            },
+            onError: (error) => {
+              repository.updateDownloadState(hash, 'error', `File ${index + 1} failed: ${error.message}`);
+              console.error(`[DownloadManager] Error on file ${index + 1}: ${error.message}`);
+              this.processQueue();
+            },
+            onPaused: () => {
+              console.log(`[DownloadManager] Download paused at file ${index + 1}/${totalFiles}`);
+            },
+          }, undefined, torrentFolder);  // Download into torrent folder
+        };
+
+        // Start downloading first file
+        downloadNextFile(0);
+      }
+    } catch (error: any) {
+      // Clean up operation tracking
+      this.activeDebridOperations.delete(hash);
+
+      // Don't set error state if cancelled (download was deleted)
+      if (operation.cancelled || error.message === 'Download cancelled') {
+        console.log(`[DownloadManager] Magnet cancelled: ${name}`);
+      } else {
+        // Only update state if download still exists
+        const dl = repository.getDownloadByHash(hash);
+        if (dl) {
+          repository.updateDownloadState(hash, 'error', error.message);
+          console.error(`[DownloadManager] Magnet error: ${name} - ${error.message}`);
         }
       }
       this.processQueue();

--- a/qbittorrent/src/types/download.ts
+++ b/qbittorrent/src/types/download.ts
@@ -7,7 +7,7 @@ export type DownloadState =
   | 'error'       // Failed with error
   | 'stalled';    // No progress for timeout
 
-export type DownloadType = 'ddl' | 'real';
+export type DownloadType = 'ddl' | 'real' | 'magnet';
 
 export interface Download {
   hash: string;


### PR DESCRIPTION
Magnet links added via addUrl() were treated as regular DDL links, causing debrid unlock to fail and curl to crash on the magnet URI. This adds dedicated magnet handling using debrid-specific endpoints (AllDebrid /magnet/upload, Real-Debrid /torrents/addMagnet, Premiumize /transfer/create).