### PR TITLE
fix(qbittorrent): use debrid torrent name for magnet downloads

### DIFF
--- a/qbittorrent/src/debrid/alldebrid.ts
+++ b/qbittorrent/src/debrid/alldebrid.ts
@@ -299,6 +299,7 @@ export class AllDebridClient implements DebridService {
 
       const result: DebridTorrentStatus = {
         id: torrentId,
+        name: magnet.filename || undefined,
         status,
         progress,
         totalSize: magnet.size,

--- a/qbittorrent/src/debrid/base.ts
+++ b/qbittorrent/src/debrid/base.ts
@@ -13,6 +13,7 @@ export interface DebridFileInfo {
  */
 export interface DebridTorrentStatus {
   id: string;
+  name?: string;             // Torrent name as reported by the debrid service
   status: 'queued' | 'downloading' | 'ready' | 'error';
   progress: number;  // 0-100
   totalSize?: number;        // Total size in bytes

--- a/qbittorrent/src/debrid/index.ts
+++ b/qbittorrent/src/debrid/index.ts
@@ -94,6 +94,7 @@ export function getTorrentEnabledServices(): DebridService[] {
 export interface DebridTorrentResult {
   service: string;
   torrentId: string;
+  name?: string;             // Torrent name from debrid service
   downloadLinks: string[];
   files?: DebridFileInfo[];  // File info with paths for multi-file torrents
   totalSize?: number;  // Total size in bytes from debrid status
@@ -146,6 +147,7 @@ export async function debridTorrent(
           return {
             service: service.name,
             torrentId,
+            name: status.name,
             downloadLinks: status.downloadLinks || status.files!.map(f => f.link),
             files: status.files,
             totalSize: status.totalSize,
@@ -217,6 +219,7 @@ export async function debridMagnet(
           return {
             service: service.name,
             torrentId,
+            name: status.name,
             downloadLinks: status.downloadLinks || status.files!.map(f => f.link),
             files: status.files,
             totalSize: status.totalSize,

--- a/qbittorrent/src/debrid/premiumize.ts
+++ b/qbittorrent/src/debrid/premiumize.ts
@@ -265,6 +265,7 @@ export class PremiumizeClient implements DebridService {
 
     const result: DebridTorrentStatus = {
       id: torrentId,
+      name: transfer.name || undefined,
       status,
       progress: Math.round(transfer.progress * 100),
     };

--- a/qbittorrent/src/debrid/realdebrid.ts
+++ b/qbittorrent/src/debrid/realdebrid.ts
@@ -263,6 +263,7 @@ export class RealDebridClient implements DebridService {
 
     const result: DebridTorrentStatus = {
       id: torrentId,
+      name: torrent.filename || undefined,
       status,
       progress: Math.round(torrent.progress),
     };

--- a/qbittorrent/src/services/download-manager.ts
+++ b/qbittorrent/src/services/download-manager.ts
@@ -906,6 +906,14 @@ class DownloadManager {
 
       console.log(`[DownloadManager] Magnet ready on ${result.service}, ${result.downloadLinks.length} file(s)`);
 
+      // Update name from debrid service if we had a generic fallback name
+      let currentName = name;
+      if (result.name && name.startsWith('magnet_')) {
+        currentName = result.name;
+        repository.updateDownloadName(hash, currentName);
+        console.log(`[DownloadManager] Updated magnet name from debrid: ${currentName}`);
+      }
+
       // If single file, download it directly
       // If multiple files, download each sequentially
       if (result.downloadLinks.length === 1) {
@@ -914,10 +922,10 @@ class DownloadManager {
 
         // Get real filename
         repository.updateDownloadStatusMessage(hash, 'Getting file info...');
-        let actualName = name;
+        let actualName = currentName;
         try {
-          actualName = await getRealFilename(debridedUrl, name);
-          if (actualName !== name) {
+          actualName = await getRealFilename(debridedUrl, currentName);
+          if (actualName !== currentName) {
             repository.updateDownloadName(hash, actualName);
           }
         } catch (error: any) {
@@ -965,7 +973,7 @@ class DownloadManager {
         console.log(`[DownloadManager] Multi-file magnet with ${result.downloadLinks.length} files`);
 
         // Create folder with torrent name
-        const torrentFolder = path.join(savePath, name);
+        const torrentFolder = path.join(savePath, currentName);
         if (!fs.existsSync(torrentFolder)) {
           fs.mkdirSync(torrentFolder, { recursive: true });
           console.log(`[DownloadManager] Created folder: ${torrentFolder}`);


### PR DESCRIPTION
When a magnet URI has no dn= parameter, the download was named magnet_<timestamp>. Now the torrent name reported by the debrid service (available after upload) is used to update the download name, giving proper filenames for both single-file and multi-file magnets.