### PR TITLE
fix(darkiworld): persist credentials across container restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,15 @@ ddl_torznab/
 
 ## Dépannage
 
+### Les identifiants Darkiworld sont perdus au redémarrage
+
+Les identifiants saisis via l'interface web sont automatiquement sauvegardés sur disque et restaurés au redémarrage du conteneur. Si ce n'est pas le cas, vérifiez que le volume de configuration est bien monté :
+
+- **docker-compose.yml** : `${DARKIWORLD_CONFIG_PATH:-./darkiworld-config}:/app/config`
+- **docker-compose.prod.yml** : volume nommé `darkiworld-config:/app/config`
+
+> **Note** : La session (cookies) n'est pas persistée — le service se ré-authentifiera automatiquement au redémarrage avec les identifiants sauvegardés.
+
 ### Les recherches ne retournent rien
 
 - Vérifier que les URLs des sites sont correctes et accessibles

--- a/darkiworld/config.py
+++ b/darkiworld/config.py
@@ -7,6 +7,7 @@ For Docker: uses parent .env file
 """
 
 import os
+import json
 import logging
 import requests
 import time
@@ -127,16 +128,55 @@ ALLDEBRID_API_URL = 'https://api.alldebrid.com/v4/link/unlock'
 # Server configuration
 PORT = int(os.getenv('DARKIWORLD_PORT', 5002))
 
+# Persistent config file path (saved to /app/config/ which should be a Docker volume)
+CONFIG_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'config')
+CONFIG_FILE = os.path.join(CONFIG_DIR, 'credentials.json')
+
+
+def _load_config_from_disk() -> dict:
+    """Load saved credentials from disk, returns defaults if file doesn't exist."""
+    defaults = {
+        'enabled': False,
+        'email': '',
+        'password': '',
+        'authenticated': False,
+    }
+    try:
+        if os.path.exists(CONFIG_FILE):
+            with open(CONFIG_FILE, 'r') as f:
+                saved = json.load(f)
+            # Merge saved values into defaults (in case new keys are added later)
+            defaults.update(saved)
+            # Always reset authenticated on startup - session cookies are not persisted
+            defaults['authenticated'] = False
+            logger.info(f"Loaded credentials from {CONFIG_FILE} (email: {defaults['email'] or 'not set'})")
+    except Exception as e:
+        logger.warning(f"Failed to load config from {CONFIG_FILE}: {e}")
+    return defaults
+
+
+def _save_config_to_disk() -> None:
+    """Save current credentials to disk for persistence across restarts."""
+    try:
+        os.makedirs(CONFIG_DIR, exist_ok=True)
+        data = {
+            'enabled': runtime_config['enabled'],
+            'email': runtime_config['email'],
+            'password': runtime_config['password'],
+        }
+        with open(CONFIG_FILE, 'w') as f:
+            json.dump(data, f, indent=2)
+        logger.info(f"Saved credentials to {CONFIG_FILE}")
+    except Exception as e:
+        logger.warning(f"Failed to save config to {CONFIG_FILE}: {e}")
+
+
 # Runtime configuration (can be updated via API)
 # This allows dynamic configuration from the indexer UI
 # Darkiworld is disabled by default - must pass login test to enable
 # Credentials are configured via the web UI, not environment variables
-runtime_config = {
-    'enabled': False,
-    'email': '',
-    'password': '',
-    'authenticated': False,
-}
+# On startup, credentials are loaded from disk if previously saved
+runtime_config = _load_config_from_disk()
 
 
 def update_runtime_config(new_config: dict) -> dict:
@@ -164,7 +204,9 @@ def update_runtime_config(new_config: dict) -> dict:
         runtime_config['password'] = new_config['password']
         runtime_config['authenticated'] = False  # Need to re-login with new password
         logger.info("Runtime config: password updated, will re-authenticate")
-    
+
+    _save_config_to_disk()
+
     return get_runtime_config()
 
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -53,6 +53,8 @@ services:
   ddl-darkiworld:
     image: ghcr.io/z-m-g/darkiworld:latest
     container_name: ddl-darkiworld
+    profiles:
+      - darkiworld
     ports:
       - "${DARKIWORLD_PORT:-5002}:5002"
     environment:
@@ -62,6 +64,7 @@ services:
       - DARKIWORLD_ALLDEBRID_KEY=${ALLDEBRID_API_KEY}
     volumes:
       - darkiworld-output:/app/output
+      - darkiworld-config:/app/config
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5002/health"]
       interval: 10s
@@ -108,4 +111,5 @@ services:
 volumes:
   dlprotect-cache:
   darkiworld-output:
+  darkiworld-config:
   qbittorrent-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - DARKIWORLD_ALLDEBRID_KEY=${ALLDEBRID_API_KEY}
     volumes:
       - ./darkiworld/output:/app/output
+      - ${DARKIWORLD_CONFIG_PATH:-./darkiworld-config}:/app/config
     healthcheck:
       test:
         [


### PR DESCRIPTION
Credentials entered via the web UI were stored only in memory and lost on every container restart. Now saved to a JSON file on a mounted volume and reloaded on startup. Also add missing darkiworld profile to prod compose.