### PR TITLE
fix(ci): use native arm64 runners instead of QEMU emulation

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -10,38 +10,93 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.platform.runner }}
     permissions:
       contents: read
       packages: write
-
     strategy:
+      fail-fast: false
       matrix:
-        include:
+        image:
           - name: ddl-torznab
             context: ./indexer
             dockerfile: ./indexer/Dockerfile
-            platforms: linux/amd64,linux/arm64
           - name: dlprotect-resolver
             context: ./botasaurus-service
             dockerfile: ./botasaurus-service/Dockerfile
-            platforms: linux/amd64,linux/arm64
           - name: ddl-qbittorrent
             context: ./qbittorrent
             dockerfile: ./qbittorrent/Dockerfile
-            platforms: linux/amd64,linux/arm64
           - name: darkiworld
             context: ./darkiworld
             dockerfile: ./darkiworld/Dockerfile
-            platforms: linux/amd64,linux/arm64
-
+        platform:
+          - runner: ubuntu-latest
+            pair: linux/amd64
+            slug: amd64
+          - runner: ubuntu-24.04-arm
+            pair: linux/arm64
+            slug: arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.image.context }}
+          file: ${{ matrix.image.dockerfile }}
+          platforms: ${{ matrix.platform.pair }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.image.name }}-${{ matrix.platform.slug }}
+          cache-to: type=gha,scope=${{ matrix.image.name }}-${{ matrix.platform.slug }},mode=max
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ matrix.image.name }}-${{ matrix.platform.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        image:
+          - ddl-torznab
+          - dlprotect-resolver
+          - ddl-qbittorrent
+          - darkiworld
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: digest-${{ matrix.image }}-*
+          merge-multiple: true
+          path: /tmp/digests
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -57,19 +112,13 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.name }}
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
           tags: |
             type=raw,value=latest
             type=sha,prefix=
 
-      - name: Build and push
-        uses: docker/build-push-action@v5
-        with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ matrix.platforms }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}@sha256:%s ' *)


### PR DESCRIPTION
Replace slow QEMU-based cross-compilation with native arm64 runners (ubuntu-24.04-arm) to fix build timeouts and "Illegal instruction" crashes. Builds each platform natively in parallel then merges into multi-arch manifests.