### PR TITLE
fix(ci): update actions to Node.js 24 and fix Dockerfile CMD format

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,13 +40,13 @@ jobs:
             slug: arm64
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ${{ matrix.image.context }}
           file: ${{ matrix.image.dockerfile }}
@@ -70,7 +70,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digest-${{ matrix.image.name }}-${{ matrix.platform.slug }}
           path: /tmp/digests/*
@@ -92,17 +92,17 @@ jobs:
           - darkiworld
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: digest-${{ matrix.image }}-*
           merge-multiple: true
           path: /tmp/digests
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -110,7 +110,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
           tags: |

--- a/botasaurus-service/Dockerfile
+++ b/botasaurus-service/Dockerfile
@@ -52,4 +52,4 @@ ENV DISPLAY=:99
 EXPOSE 5000
 
 # Run with xvfb for real browser (headless=False)
-CMD xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" python main.py
+CMD ["sh", "-c", "xvfb-run --auto-servernum --server-args='-screen 0 1920x1080x24' python main.py"]


### PR DESCRIPTION
Bump all GitHub Actions to latest versions supporting Node.js 24 (checkout@v6, build-push-action@v7, login-action@v4, setup-buildx@v4, metadata-action@v6, upload/download-artifact@v7). Use JSON format for CMD in botasaurus-service Dockerfile to handle OS signals properly.