### PR TITLE
feat(qbittorrent): improve UI with status messages, bulk actions and  error feedback

### DIFF
--- a/qbittorrent/ui/src/App.vue
+++ b/qbittorrent/ui/src/App.vue
@@ -5,6 +5,7 @@ import LoginForm from './components/LoginForm.vue'
 import TorrentList from './components/TorrentList.vue'
 import AddTorrentModal from './components/AddTorrentModal.vue'
 import Navbar from './components/Navbar.vue'
+import ToastNotification from './components/ToastNotification.vue'
 
 const store = useTorrentsStore()
 const showAddModal = ref(false)
@@ -48,6 +49,16 @@ async function handleLogout() {
 
 <template>
   <div class="min-h-screen bg-gray-100">
+    <!-- Connection lost banner -->
+    <Transition name="banner">
+      <div
+        v-if="store.connectionLost && store.isAuthenticated"
+        class="bg-yellow-400 text-yellow-900 text-sm text-center py-2 px-4 font-medium"
+      >
+        Connection lost — reconnecting...
+      </div>
+    </Transition>
+
     <template v-if="!store.isAuthenticated">
       <div class="flex items-center justify-center min-h-screen">
         <LoginForm @login="handleLogin" />
@@ -60,5 +71,21 @@ async function handleLogout() {
       </main>
       <AddTorrentModal v-if="showAddModal" @close="showAddModal = false" />
     </template>
+
+    <ToastNotification />
   </div>
 </template>
+
+<style scoped>
+.banner-enter-active,
+.banner-leave-active {
+  transition: all 0.3s ease;
+}
+.banner-enter-from,
+.banner-leave-to {
+  opacity: 0;
+  max-height: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+</style>

--- a/qbittorrent/ui/src/api/client.ts
+++ b/qbittorrent/ui/src/api/client.ts
@@ -104,7 +104,7 @@ class ApiClient {
     const formData = new URLSearchParams()
     formData.append('hashes', hashes.join('|'))
 
-    await fetch(`${this.baseUrl}/api/v2/torrents/pause`, {
+    const response = await fetch(`${this.baseUrl}/api/v2/torrents/pause`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -112,13 +112,14 @@ class ApiClient {
       body: formData,
       credentials: 'include',
     })
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
   }
 
   async resumeTorrents(hashes: string[]): Promise<void> {
     const formData = new URLSearchParams()
     formData.append('hashes', hashes.join('|'))
 
-    await fetch(`${this.baseUrl}/api/v2/torrents/resume`, {
+    const response = await fetch(`${this.baseUrl}/api/v2/torrents/resume`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -126,6 +127,7 @@ class ApiClient {
       body: formData,
       credentials: 'include',
     })
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
   }
 
   async deleteTorrents(hashes: string[], deleteFiles: boolean): Promise<void> {
@@ -133,7 +135,7 @@ class ApiClient {
     formData.append('hashes', hashes.join('|'))
     formData.append('deleteFiles', deleteFiles ? 'true' : 'false')
 
-    await fetch(`${this.baseUrl}/api/v2/torrents/delete`, {
+    const response = await fetch(`${this.baseUrl}/api/v2/torrents/delete`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
@@ -141,6 +143,7 @@ class ApiClient {
       body: formData,
       credentials: 'include',
     })
+    if (!response.ok) throw new Error(`HTTP ${response.status}`)
   }
 }
 

--- a/qbittorrent/ui/src/components/ToastNotification.vue
+++ b/qbittorrent/ui/src/components/ToastNotification.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { useToastStore } from '../stores/toast'
+
+const toast = useToastStore()
+</script>
+
+<template>
+  <div class="fixed bottom-4 right-4 flex flex-col gap-2 z-50 max-w-sm w-full pointer-events-none">
+    <TransitionGroup name="toast">
+      <div
+        v-for="t in toast.toasts"
+        :key="t.id"
+        :class="[
+          'px-4 py-3 rounded-lg shadow-lg text-white text-sm pointer-events-auto',
+          t.type === 'success' ? 'bg-green-600' :
+          t.type === 'error'   ? 'bg-red-600'   : 'bg-blue-600'
+        ]"
+      >
+        {{ t.message }}
+      </div>
+    </TransitionGroup>
+  </div>
+</template>
+
+<style scoped>
+.toast-enter-active,
+.toast-leave-active {
+  transition: all 0.3s ease;
+}
+.toast-enter-from,
+.toast-leave-to {
+  opacity: 0;
+  transform: translateX(110%);
+}
+</style>

--- a/qbittorrent/ui/src/components/TorrentItem.vue
+++ b/qbittorrent/ui/src/components/TorrentItem.vue
@@ -1,22 +1,26 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { ref, computed } from 'vue'
 import { useTorrentsStore } from '../stores/torrents'
 import type { TorrentInfo } from '../api/client'
 
 const props = defineProps<{
   torrent: TorrentInfo
+  selected?: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'toggle-select'): void
 }>()
 
 const store = useTorrentsStore()
+const actionPending = ref(false)
 
 const progressPercent = computed(() => {
-  // Force 100% for completed torrents
   if (props.torrent.state === 'uploading' || props.torrent.state === 'stoppedUP') return 100
   return Math.round(props.torrent.progress * 100)
 })
 
 const displayDownloaded = computed(() => {
-  // For completed, show total size as downloaded
   if (props.torrent.state === 'uploading' || props.torrent.state === 'stoppedUP') return props.torrent.size
   return props.torrent.downloaded
 })
@@ -36,10 +40,6 @@ const statusColor = computed(() => {
 })
 
 const statusLabel = computed(() => {
-  // If there's a status message, show it instead of the generic state
-  if (props.torrent.status_message) {
-    return props.torrent.status_message
-  }
   switch (props.torrent.state) {
     case 'downloading': return 'Downloading'
     case 'uploading':
@@ -48,12 +48,17 @@ const statusLabel = computed(() => {
     case 'pausedUP': return 'Paused'
     case 'queuedDL': return 'Queued'
     case 'checkingDL': return 'Checking'
-    case 'moving': return 'Moving...'
+    case 'moving': return 'Moving'
     case 'error': return 'Error'
     case 'stalledDL': return 'Stalled'
     default: return props.torrent.state
   }
 })
+
+const showStatusMessage = computed(() =>
+  !!props.torrent.status_message &&
+  ['checkingDL', 'downloading', 'queuedDL', 'moving'].includes(props.torrent.state)
+)
 
 const isPaused = computed(() =>
   props.torrent.state === 'pausedDL' || props.torrent.state === 'pausedUP'
@@ -86,56 +91,94 @@ function formatEta(seconds: number): string {
 }
 
 async function handlePauseResume() {
-  if (isPaused.value) {
-    await store.resumeTorrents([props.torrent.hash])
-  } else {
-    await store.pauseTorrents([props.torrent.hash])
+  actionPending.value = true
+  try {
+    if (isPaused.value) {
+      await store.resumeTorrents([props.torrent.hash])
+    } else {
+      await store.pauseTorrents([props.torrent.hash])
+    }
+  } finally {
+    actionPending.value = false
   }
 }
 
 async function handleDelete() {
   if (confirm(`Delete "${props.torrent.name}"?`)) {
     const deleteFiles = confirm('Also delete downloaded files?')
-    await store.deleteTorrents([props.torrent.hash], deleteFiles)
+    actionPending.value = true
+    try {
+      await store.deleteTorrents([props.torrent.hash], deleteFiles)
+    } finally {
+      actionPending.value = false
+    }
   }
 }
 </script>
 
 <template>
-  <div class="bg-white rounded-lg shadow p-4">
+  <div
+    class="bg-white rounded-lg shadow p-4"
+    :class="{ 'ring-2 ring-blue-400': selected }"
+  >
     <div class="flex items-start justify-between mb-2">
-      <div class="flex-1 min-w-0">
-        <h3 class="font-medium text-gray-900 truncate" :title="torrent.name">
-          {{ torrent.name }}
-        </h3>
-        <div class="flex items-center space-x-2 text-sm text-gray-500 mt-1">
-          <span :class="[statusColor, 'px-2 py-0.5 rounded text-white text-xs']">
-            {{ statusLabel }}
-          </span>
-          <span v-if="torrent.category" class="bg-gray-200 px-2 py-0.5 rounded text-xs">
-            {{ torrent.category }}
-          </span>
+      <div class="flex items-start gap-3 flex-1 min-w-0">
+        <!-- Checkbox -->
+        <input
+          type="checkbox"
+          :checked="selected"
+          @change="emit('toggle-select')"
+          class="mt-1 h-4 w-4 rounded border-gray-300 text-blue-600 cursor-pointer flex-shrink-0"
+        />
+
+        <div class="flex-1 min-w-0">
+          <h3 class="font-medium text-gray-900 truncate" :title="torrent.name">
+            {{ torrent.name }}
+          </h3>
+          <div class="flex items-center space-x-2 text-sm text-gray-500 mt-1">
+            <span :class="[statusColor, 'px-2 py-0.5 rounded text-white text-xs']">
+              {{ statusLabel }}
+            </span>
+            <span v-if="torrent.category" class="bg-gray-200 px-2 py-0.5 rounded text-xs">
+              {{ torrent.category }}
+            </span>
+          </div>
+          <!-- Status message (active states) -->
+          <p v-if="showStatusMessage" class="text-xs text-gray-500 italic mt-1">
+            {{ torrent.status_message }}
+          </p>
         </div>
       </div>
 
-      <div class="flex space-x-2 ml-4">
+      <div class="flex space-x-2 ml-4 flex-shrink-0">
         <button
           v-if="canPause || isPaused"
           @click="handlePauseResume"
+          :disabled="actionPending"
           :class="[
-            'px-3 py-1 rounded text-sm font-medium',
+            'px-3 py-1 rounded text-sm font-medium flex items-center gap-1',
             isPaused
               ? 'bg-green-100 text-green-700 hover:bg-green-200'
-              : 'bg-yellow-100 text-yellow-700 hover:bg-yellow-200'
+              : 'bg-yellow-100 text-yellow-700 hover:bg-yellow-200',
+            'disabled:opacity-50 disabled:cursor-not-allowed'
           ]"
         >
-          {{ isPaused ? 'Resume' : 'Pause' }}
+          <svg v-if="actionPending" class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
+          </svg>
+          <span v-else>{{ isPaused ? 'Resume' : 'Pause' }}</span>
         </button>
         <button
           @click="handleDelete"
-          class="px-3 py-1 rounded text-sm font-medium bg-red-100 text-red-700 hover:bg-red-200"
+          :disabled="actionPending"
+          class="px-3 py-1 rounded text-sm font-medium bg-red-100 text-red-700 hover:bg-red-200 flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          Delete
+          <svg v-if="actionPending" class="animate-spin h-3 w-3" fill="none" viewBox="0 0 24 24">
+            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
+            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/>
+          </svg>
+          <span v-else>Delete</span>
         </button>
       </div>
     </div>
@@ -149,7 +192,7 @@ async function handleDelete() {
     </div>
 
     <!-- Error message -->
-    <div v-if="torrent.state === 'error' && torrent.error_message" class="text-sm text-red-600 mb-2">
+    <div v-if="torrent.state === 'error' && torrent.error_message" class="text-xs text-red-600 mb-2 break-words">
       {{ torrent.error_message }}
     </div>
 

--- a/qbittorrent/ui/src/components/TorrentList.vue
+++ b/qbittorrent/ui/src/components/TorrentList.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { ref, computed } from 'vue'
 import { useTorrentsStore } from '../stores/torrents'
 import TorrentItem from './TorrentItem.vue'
 
@@ -11,6 +12,75 @@ const filters = [
   { value: 'paused', label: 'Paused' },
   { value: 'errored', label: 'Errored' },
 ]
+
+// Selection
+const selectedHashes = ref<Set<string>>(new Set())
+
+const allSelected = computed(() =>
+  store.filteredTorrents.length > 0 &&
+  store.filteredTorrents.every(t => selectedHashes.value.has(t.hash))
+)
+
+const someSelected = computed(() => selectedHashes.value.size > 0)
+
+function toggleSelect(hash: string) {
+  const next = new Set(selectedHashes.value)
+  if (next.has(hash)) {
+    next.delete(hash)
+  } else {
+    next.add(hash)
+  }
+  selectedHashes.value = next
+}
+
+function toggleSelectAll() {
+  if (allSelected.value) {
+    selectedHashes.value = new Set()
+  } else {
+    selectedHashes.value = new Set(store.filteredTorrents.map(t => t.hash))
+  }
+}
+
+// Bulk actions
+const bulkPending = ref(false)
+
+async function bulkPause() {
+  const hashes = [...selectedHashes.value]
+  if (!hashes.length) return
+  bulkPending.value = true
+  try {
+    await store.pauseTorrents(hashes)
+    selectedHashes.value = new Set()
+  } finally {
+    bulkPending.value = false
+  }
+}
+
+async function bulkResume() {
+  const hashes = [...selectedHashes.value]
+  if (!hashes.length) return
+  bulkPending.value = true
+  try {
+    await store.resumeTorrents(hashes)
+    selectedHashes.value = new Set()
+  } finally {
+    bulkPending.value = false
+  }
+}
+
+async function bulkDelete() {
+  const hashes = [...selectedHashes.value]
+  if (!hashes.length) return
+  if (!confirm(`Delete ${hashes.length} download(s)?`)) return
+  const deleteFiles = confirm('Also delete downloaded files?')
+  bulkPending.value = true
+  try {
+    await store.deleteTorrents(hashes, deleteFiles)
+    selectedHashes.value = new Set()
+  } finally {
+    bulkPending.value = false
+  }
+}
 </script>
 
 <template>
@@ -32,6 +102,44 @@ const filters = [
       </button>
     </div>
 
+    <!-- Bulk action bar -->
+    <Transition name="slide-down">
+      <div v-if="someSelected" class="flex items-center gap-3 bg-blue-50 border border-blue-200 rounded-lg px-4 py-2 mb-4">
+        <span class="text-sm text-blue-700 font-medium">
+          {{ selectedHashes.size }} selected
+        </span>
+        <div class="flex gap-2 ml-auto">
+          <button
+            @click="bulkResume"
+            :disabled="bulkPending"
+            class="px-3 py-1 rounded text-sm font-medium bg-green-100 text-green-700 hover:bg-green-200 disabled:opacity-50"
+          >
+            Resume
+          </button>
+          <button
+            @click="bulkPause"
+            :disabled="bulkPending"
+            class="px-3 py-1 rounded text-sm font-medium bg-yellow-100 text-yellow-700 hover:bg-yellow-200 disabled:opacity-50"
+          >
+            Pause
+          </button>
+          <button
+            @click="bulkDelete"
+            :disabled="bulkPending"
+            class="px-3 py-1 rounded text-sm font-medium bg-red-100 text-red-700 hover:bg-red-200 disabled:opacity-50"
+          >
+            Delete
+          </button>
+          <button
+            @click="selectedHashes = new Set()"
+            class="px-3 py-1 rounded text-sm font-medium bg-gray-100 text-gray-600 hover:bg-gray-200"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </Transition>
+
     <!-- Loading -->
     <div v-if="store.isLoading && store.torrents.length === 0" class="text-center py-12 text-gray-500">
       Loading...
@@ -44,11 +152,37 @@ const filters = [
 
     <!-- Torrent list -->
     <div v-else class="space-y-2">
+      <!-- Select all header -->
+      <div class="flex items-center gap-2 px-1 pb-1">
+        <input
+          type="checkbox"
+          :checked="allSelected"
+          :indeterminate="someSelected && !allSelected"
+          @change="toggleSelectAll"
+          class="h-4 w-4 rounded border-gray-300 text-blue-600 cursor-pointer"
+        />
+        <span class="text-sm text-gray-500">Select all</span>
+      </div>
+
       <TorrentItem
         v-for="torrent in store.filteredTorrents"
         :key="torrent.hash"
         :torrent="torrent"
+        :selected="selectedHashes.has(torrent.hash)"
+        @toggle-select="toggleSelect(torrent.hash)"
       />
     </div>
   </div>
 </template>
+
+<style scoped>
+.slide-down-enter-active,
+.slide-down-leave-active {
+  transition: all 0.2s ease;
+}
+.slide-down-enter-from,
+.slide-down-leave-to {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+</style>

--- a/qbittorrent/ui/src/stores/toast.ts
+++ b/qbittorrent/ui/src/stores/toast.ts
@@ -1,0 +1,26 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+
+export type ToastType = 'success' | 'error' | 'info'
+
+interface Toast {
+  id: number
+  message: string
+  type: ToastType
+}
+
+export const useToastStore = defineStore('toast', () => {
+  const toasts = ref<Toast[]>([])
+  let nextId = 0
+
+  function show(message: string, type: ToastType = 'info') {
+    const id = nextId++
+    // Keep max 3 toasts
+    toasts.value = [...toasts.value.slice(-2), { id, message, type }]
+    setTimeout(() => {
+      toasts.value = toasts.value.filter(t => t.id !== id)
+    }, 4000)
+  }
+
+  return { toasts, show }
+})

--- a/qbittorrent/ui/src/stores/torrents.ts
+++ b/qbittorrent/ui/src/stores/torrents.ts
@@ -1,6 +1,7 @@
 import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import { apiClient, type TorrentInfo } from '../api/client'
+import { useToastStore } from './toast'
 
 export const useTorrentsStore = defineStore('torrents', () => {
   const torrents = ref<TorrentInfo[]>([])
@@ -8,6 +9,7 @@ export const useTorrentsStore = defineStore('torrents', () => {
   const isLoading = ref(false)
   const error = ref<string | null>(null)
   const isAuthenticated = ref(false)
+  const connectionLost = ref(false)
 
   const filteredTorrents = computed(() => {
     if (filter.value === 'all') return torrents.value
@@ -56,9 +58,12 @@ export const useTorrentsStore = defineStore('torrents', () => {
       }
       error.value = null
       torrents.value = await apiClient.getTorrents()
+      connectionLost.value = false
     } catch (e: any) {
       if (e.message === 'Not authenticated') {
         isAuthenticated.value = false
+      } else {
+        connectionLost.value = true
       }
       error.value = e.message
     } finally {
@@ -85,18 +90,39 @@ export const useTorrentsStore = defineStore('torrents', () => {
   }
 
   async function pauseTorrents(hashes: string[]): Promise<void> {
-    await apiClient.pauseTorrents(hashes)
-    await fetchTorrents()
+    const toast = useToastStore()
+    try {
+      await apiClient.pauseTorrents(hashes)
+      await fetchTorrents()
+      toast.show('Download paused', 'success')
+    } catch (e: any) {
+      toast.show(`Failed to pause: ${e.message}`, 'error')
+      throw e
+    }
   }
 
   async function resumeTorrents(hashes: string[]): Promise<void> {
-    await apiClient.resumeTorrents(hashes)
-    await fetchTorrents()
+    const toast = useToastStore()
+    try {
+      await apiClient.resumeTorrents(hashes)
+      await fetchTorrents()
+      toast.show('Download resumed', 'success')
+    } catch (e: any) {
+      toast.show(`Failed to resume: ${e.message}`, 'error')
+      throw e
+    }
   }
 
   async function deleteTorrents(hashes: string[], deleteFiles: boolean): Promise<void> {
-    await apiClient.deleteTorrents(hashes, deleteFiles)
-    await fetchTorrents()
+    const toast = useToastStore()
+    try {
+      await apiClient.deleteTorrents(hashes, deleteFiles)
+      await fetchTorrents()
+      toast.show('Download deleted', 'success')
+    } catch (e: any) {
+      toast.show(`Failed to delete: ${e.message}`, 'error')
+      throw e
+    }
   }
 
   function setFilter(newFilter: string): void {
@@ -121,6 +147,7 @@ export const useTorrentsStore = defineStore('torrents', () => {
     isLoading,
     error,
     isAuthenticated,
+    connectionLost,
     stats,
     login,
     logout,


### PR DESCRIPTION
  Description :                                                              
  ## Summary
            
  - **Status messages**: affichage du `status_message` backend sous le badge
  d'état pendant les phases actives                                         
  - **Bulk actions**: cases à cocher + "Select all" + barre Resume/Pause/Delete
  - **Toast notifications**: feedback visuel après chaque action,              
  auto-disparition 4s                                                           
  - **Connection lost banner**: bannière jaune si le polling échoue
  - **API error handling**: pause/resume/delete lèvent une erreur si response.ok
   est false                                                                    
  - **Loading states**: spinner sur les boutons pendant l'opération
  - **Error message**: break-words pour éviter les débordements