### PR TITLE
fix(botasaurus): update DLProtect iframe position to (832, 640)

### DIFF
--- a/botasaurus-service/main.py
+++ b/botasaurus-service/main.py
@@ -246,8 +246,10 @@ def resolve_dlprotect(driver: Driver, url: str):
 
             try:
                 # Locate iframe containing the Cloudflare challenge (at position 840, 290)
-                print("[DLProtect] Getting iframe at position (840, 290)...")
-                iframe = driver.get_element_at_point(840, 290)
+#                 print("[DLProtect] Getting iframe at position (840, 290)...")
+#                 iframe = driver.get_element_at_point(840, 290)
+                print("[DLProtect] Getting iframe at position (832, 640)...")
+                iframe = driver.get_element_at_point(832, 640)
                 print(f"[DLProtect] Iframe element: {iframe}")
 
                 # Find checkbox element within the iframe (at 30, 30 inside iframe)

--- a/indexer/src/routes/torznab.ts
+++ b/indexer/src/routes/torznab.ts
@@ -498,3 +498,5 @@ export async function torznabRoutes(app: FastifyInstance): Promise<void> {
     return handleTorznabRequest(request, reply, site, hosters);
   });
 }
+
+


### PR DESCRIPTION
The previous coordinates (840, 290) no longer locate the Cloudflare challenge iframe on the DLProtect page; the old call is left commented out as reference in case the layout shifts again.