### PR TITLE
fix(botasaurus): adjust Turnstile iframe coords and destination link …

### DIFF
--- a/botasaurus-service/main.py
+++ b/botasaurus-service/main.py
@@ -248,8 +248,8 @@ def resolve_dlprotect(driver: Driver, url: str):
                 # Locate iframe containing the Cloudflare challenge (at position 840, 290)
 #                 print("[DLProtect] Getting iframe at position (840, 290)...")
 #                 iframe = driver.get_element_at_point(840, 290)
-                print("[DLProtect] Getting iframe at position (832, 640)...")
-                iframe = driver.get_element_at_point(832, 640)
+                print("[DLProtect] Getting iframe at position (832, 568)...")
+                iframe = driver.get_element_at_point(832, 568)
                 print(f"[DLProtect] Iframe element: {iframe}")
 
                 # Find checkbox element within the iframe (at 30, 30 inside iframe)
@@ -331,7 +331,7 @@ def resolve_dlprotect(driver: Driver, url: str):
     try:
         while waited < max_wait:
             link = driver.run_js("""
-                const container = document.querySelector('#protected-container .col-md-12 a');
+                const container = document.querySelector('main.content-centered div.dest-box a.dest-url');
                 return container ? container.href : null;
             """)
             if link and not is_dlprotect_link(link):


### PR DESCRIPTION
…selector

DL-Protect updated their layout: the Cloudflare Turnstile iframe is now at (832, 568) instead of (832, 640), and the resolved destination link moved from #protected-container to a new
main.content-centered .dest-box a.dest-url selector. End-to-end test on https://dl-protect.link/6221c5cd resolved successfully in 34s.